### PR TITLE
Created extension method to return span containing header + value

### DIFF
--- a/source/Scribbly.Cubby/Stores/CubbyStoreFactory.cs
+++ b/source/Scribbly.Cubby/Stores/CubbyStoreFactory.cs
@@ -33,7 +33,7 @@ public sealed class CubbyStoreFactory(IOptions<CubbyServerOptions> options, Time
         var cubbyOptions = options.Value;
         return cubbyOptions switch
         {
-            { Store: CubbyServerOptions.StoreType.Sharded } => SharedConcurrentStore.FromOptions(cubbyOptions, provider),
+            { Store: CubbyServerOptions.StoreType.Sharded } => ShardedConcurrentStore.FromOptions(cubbyOptions, provider),
             { Store: CubbyServerOptions.StoreType.Concurrent } => ConcurrentStore.FromOptions(cubbyOptions, provider),
             
             _ => throw new ArgumentOutOfRangeException(nameof(options), options, null)

--- a/source/Scribbly.Cubby/Stores/ICubbyStore.cs
+++ b/source/Scribbly.Cubby/Stores/ICubbyStore.cs
@@ -19,7 +19,7 @@ public interface ICubbyStore : ICubbyStoreEviction, IDisposable
     /// <param name="key">The key for the value requested</param>
     /// <returns>The value from the store</returns>
     /// <exception cref="InvalidOperationException">When the key is not found in the store</exception>
-    ReadOnlyMemory<byte> Get(BytesKey key);
+    ReadOnlySpan<byte> Get(BytesKey key);
 
     /// <summary>
     /// Attempts to Get the value from the cache

--- a/source/Scribbly.Cubby/Structure/CacheEntryStructLayoutExtensions.cs
+++ b/source/Scribbly.Cubby/Structure/CacheEntryStructLayoutExtensions.cs
@@ -31,6 +31,22 @@ internal static class CacheEntryStructLayoutExtensions
 
     extension(byte[] cacheData)
     {
+        /// <summary>
+        /// Returns a span containing the header as well as all value bytes
+        /// </summary>
+        /// <returns>The span containing the entire entry</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal Span<byte> GetEntryFromBuffer()
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(cacheData.Length, EntryLayout.HeaderSize);
+
+            var span = cacheData.AsSpan();
+
+            var length = span.GetValueLength();
+
+            return span[..(EntryLayout.HeaderSize + length)];
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Span<byte> GetHeader()
         {

--- a/tests/Scribbly.Cubby.Benchmarks/Stores/StoreGetStructBenchmarks.cs
+++ b/tests/Scribbly.Cubby.Benchmarks/Stores/StoreGetStructBenchmarks.cs
@@ -14,7 +14,7 @@ public class StoreGetStructBenchmarks
     private BytesKey[] _keys = null!;
     private byte[][] _values = null!;
 
-    private SharedConcurrentStore _sharedEntries = null!;
+    private ShardedConcurrentStore _shardedEntries = null!;
     
     [GlobalSetup]
     public void Setup()
@@ -30,11 +30,11 @@ public class StoreGetStructBenchmarks
             _values[i] = new byte[64];
         }
 
-        _sharedEntries = SharedConcurrentStore.FromOptions(options, TimeProvider.System);
+        _shardedEntries = ShardedConcurrentStore.FromOptions(options, TimeProvider.System);
         
         for (int i = 0; i < EntryCount; i++)
         {
-            _sharedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
+            _shardedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
         }
     }
 
@@ -43,7 +43,7 @@ public class StoreGetStructBenchmarks
     {
         Parallel.For(0, EntryCount, new ParallelOptions { MaxDegreeOfParallelism = Threads }, i =>
         {
-            _sharedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
+            _shardedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
         });
     }
 }

--- a/tests/Scribbly.Cubby.Benchmarks/Stores/StorePutStructBenchmarks.cs
+++ b/tests/Scribbly.Cubby.Benchmarks/Stores/StorePutStructBenchmarks.cs
@@ -14,7 +14,7 @@ public class StorePutStructBenchmarks
     private BytesKey[] _keys = null!;
     private byte[][] _values = null!;
 
-    private SharedConcurrentStore _sharedEntries = null!;
+    private ShardedConcurrentStore _shardedEntries = null!;
     
     [GlobalSetup]
     public void Setup()
@@ -30,7 +30,7 @@ public class StorePutStructBenchmarks
             _values[i] = new byte[64];
         }
 
-        _sharedEntries = SharedConcurrentStore.FromOptions(options, TimeProvider.System);
+        _shardedEntries = ShardedConcurrentStore.FromOptions(options, TimeProvider.System);
     }
     
     [Benchmark]
@@ -38,7 +38,7 @@ public class StorePutStructBenchmarks
     {
         Parallel.For(0, EntryCount, new ParallelOptions { MaxDegreeOfParallelism = Threads }, i =>
         {
-            _sharedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
+            _shardedEntries.Put(_keys[i], _values[i], CacheEntryOptions.None);
         });
     }
 }

--- a/tests/Scribbly.Cubby.IntegrationTests/Tests/Transports/Put_Entry_Client_TestBase.cs
+++ b/tests/Scribbly.Cubby.IntegrationTests/Tests/Transports/Put_Entry_Client_TestBase.cs
@@ -44,7 +44,7 @@ public abstract class Put_Entry_Client_TestBase<T>(WebApplicationFactory<T> appl
 
         await client.Put(key, array, CacheEntryOptions.None, CancellationToken.None);
 
-        var value = store.Get(key).Span.GetValue();
+        var value = store.Get(key).GetValue();
         
         value.ToArray().Should().BeEquivalentTo(array);
     }
@@ -87,7 +87,7 @@ public abstract class Put_Entry_Client_TestBase<T>(WebApplicationFactory<T> appl
         
         await client.Put(key, array, CacheEntryOptions.None, CancellationToken.None);
         
-        var value = store.Get(key).Span.GetValue();
+        var value = store.Get(key).GetValue();
 
         value.ToArray().Should().BeEquivalentTo(array);
     }

--- a/tests/Scribbly.Cubby.UnitTests/Structure/LayoutExtension_Tests/GetCacheEntry_ByteArray_Extensions_Tests.cs
+++ b/tests/Scribbly.Cubby.UnitTests/Structure/LayoutExtension_Tests/GetCacheEntry_ByteArray_Extensions_Tests.cs
@@ -1,0 +1,66 @@
+﻿using System.Buffers;
+using FluentAssertions;
+using Scribbly.Cubby.Stores;
+
+namespace Scribbly.Cubby.UnitTests.Structure.LayoutExtension_Tests;
+
+public class GetCacheEntry_ByteArray_Extensions_Tests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(15)]
+    [InlineData(23)]
+    public void Given_ArrayShorterThan_HeaderRequirements_Should_Throw_ArgOutOfRange(int length)
+    {
+        byte[] buffer = new byte[length];
+        Random.Shared.NextBytes(buffer);
+
+        var act = () =>
+        {
+            buffer.GetEntryFromBuffer();
+        };
+
+        act.Should().ThrowExactly<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData(24)]
+    [InlineData(1000)]
+    [InlineData(24_000)]
+    public void Given_ArrayGreaterOrEqualTo_HeaderRequirements_Should_Not_Throw_ArgOutOfRange(int length)
+    {
+        byte[] array = new byte[length];
+        Random.Shared.NextBytes(array);
+        
+        var act = () =>
+        {
+            var buffer = array.RentCacheEntryArray(CacheEntryOptions.None);
+            try
+            {
+                buffer.GetEntryFromBuffer();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        };
+        
+        act.Should().NotThrow();
+    }
+    
+    [Theory]
+    [InlineData(24)]
+    [InlineData(1000)]
+    [InlineData(24_000)]
+    public void Given_ArrayGreaterOrEqualTo_HeaderRequirements_Should_Return_AllRequiredData(int length)
+    {
+        byte[] array = new byte[length];
+        Random.Shared.NextBytes(array);
+        
+        var buffer = array.RentCacheEntryArray(CacheEntryOptions.None);
+        
+        var entry = buffer.GetEntryFromBuffer();
+        
+        entry.Length.Should().Be(length + 24);
+    }
+}


### PR DESCRIPTION
# Scribbly Pull Request

## Description

Stores now only return the bytes inside the entry.  Array pooled sourced caches are stored with "extra" trailing bytes

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have executed all the unit tests
- [x] I have compiled and executed the application
- [x] I have updated the documentation to reflect my changes

## Github Issues

closes #39 